### PR TITLE
Add identity-specific sessions management to identity details page

### DIFF
--- a/src/features/sessions/hooks/index.ts
+++ b/src/features/sessions/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from './useSessions';
 export * from './useStableSessions';
+export * from './useIdentitySessions';

--- a/src/features/sessions/hooks/useIdentitySessions.ts
+++ b/src/features/sessions/hooks/useIdentitySessions.ts
@@ -1,0 +1,34 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { listIdentitySessions, deleteIdentitySessions } from '@/services/kratos/endpoints/sessions';
+
+// Hook to fetch sessions for a specific identity
+export const useIdentitySessions = (identityId: string, options?: { enabled?: boolean }) => {
+  const { enabled = true } = options || {};
+
+  return useQuery({
+    queryKey: ['identity-sessions', identityId],
+    queryFn: () =>
+      listIdentitySessions({
+        id: identityId,
+      }),
+    enabled: enabled && !!identityId,
+    staleTime: 30000, // 30 seconds
+    refetchOnWindowFocus: false,
+    retry: 2,
+  });
+};
+
+// Hook to delete all sessions for a specific identity
+export const useDeleteIdentitySessions = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (identityId: string) => deleteIdentitySessions(identityId),
+    onSuccess: (_, identityId) => {
+      // Invalidate identity sessions
+      queryClient.invalidateQueries({ queryKey: ['identity-sessions', identityId] });
+      // Also invalidate general sessions list in case they're viewing that too
+      queryClient.invalidateQueries({ queryKey: ['sessions'] });
+    },
+  });
+};

--- a/src/services/kratos/endpoints/sessions.ts
+++ b/src/services/kratos/endpoints/sessions.ts
@@ -255,3 +255,9 @@ export async function extendSession(id: string) {
   const adminApi = getAdminApi();
   return await adminApi.extendSession({ id });
 }
+
+// Delete all sessions for a specific identity
+export async function deleteIdentitySessions(identityId: string) {
+  const adminApi = getAdminApi();
+  return await adminApi.deleteIdentitySessions({ id: identityId });
+}


### PR DESCRIPTION
- Add Sessions section to identity details page with full session management
- Implement Delete All Sessions button with confirmation dialog and warning
- Create useIdentitySessions and useDeleteIdentitySessions hooks for API integration
- Add deleteIdentitySessions API endpoint to Kratos sessions service
- Reuse existing SessionsTable and SessionDetailDialog components for consistency
- Support clickable session rows with detailed session view and management actions
- Optimize performance with proper cache invalidation and re-render control