### PR TITLE
Support 32-bit and 64-bit ARM platforms

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -33,10 +33,11 @@ jobs:
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Build & push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             dhiagharsallaoui/kratos-admin-ui:latest
             dhiagharsallaoui/kratos-admin-ui:${{ github.sha }}


### PR DESCRIPTION
I really like this UI - thank you!

It's a perfect fit for my homelab setup but currently lacks a ARM64 compatible docker image (e.g. for Raspberry Pi).

I also tried adding `linux/arm/v7` as a platform to also support older Raspberry Pi models and other 32 bit platforms (e.g. Pi Zero 1). Unfortunately this build currently fails so I didn't added it to the PR (see https://github.com/tailwindlabs/tailwindcss/issues/17958#issuecomment-3079192052)