### PR TITLE
Make identity edit modal schema-aware

### DIFF
--- a/src/features/identities/components/CreateIdentityForm.tsx
+++ b/src/features/identities/components/CreateIdentityForm.tsx
@@ -1,11 +1,8 @@
 import React, { useState } from 'react';
-import { TextField as MuiTextField } from '@mui/material';
-import { useTheme } from '@mui/material';
 import { MenuItem } from '@/components/ui';
 import { Save, Cancel } from '@mui/icons-material';
-import { ActionBar, Alert, Autocomplete, Box, Button, Card, FormControl, InputLabel, Select, Spinner, Typography } from '@/components/ui';
+import { ActionBar, Alert, Box, Button, Card, FormControl, InputLabel, Select, Spinner, Typography } from '@/components/ui';
 import Form from '@rjsf/mui';
-import { RJSFSchema, UiSchema, WidgetProps, FieldTemplateProps, ObjectFieldTemplateProps, SubmitButtonProps } from '@rjsf/utils';
 import validator from '@rjsf/validator-ajv8';
 
 // Add custom format for tel to avoid validation warnings
@@ -16,398 +13,24 @@ validator.ajv.addFormat('tel', {
     return typeof data === 'string' && data.length > 0;
   },
 });
-import parsePhoneNumber, { isValidPhoneNumber, getCountries, getCountryCallingCode, CountryCode } from 'libphonenumber-js';
 import { useCreateIdentity } from '../hooks/useIdentities';
 import { useSchemas } from '@/features/schemas/hooks/useSchemas';
 import { useRouter } from 'next/navigation';
 import { IdentitySchemaContainer } from '@ory/kratos-client';
+import {
+  TelWidget,
+  TextWidget,
+  FieldTemplate,
+  ObjectFieldTemplate,
+  SubmitButton,
+  convertKratosSchemaToRJSF,
+  createUISchema,
+} from './shared-form-widgets';
 
 interface CreateIdentityFormProps {
   onSuccess?: () => void;
   onCancel?: () => void;
 }
-
-// Memoize country options for autocomplete to avoid recalculation
-const getCountryOptions = () => {
-  return getCountries()
-    .map((countryCode) => {
-      const callingCode = getCountryCallingCode(countryCode);
-      return {
-        code: countryCode,
-        name: new Intl.DisplayNames(['en'], { type: 'region' }).of(countryCode) || countryCode,
-        callingCode: `+${callingCode}`,
-        label: `${new Intl.DisplayNames(['en'], { type: 'region' }).of(countryCode)} (+${callingCode})`,
-      };
-    })
-    .sort((a, b) => a.name.localeCompare(b.name));
-};
-
-// Custom tel widget component with libphonenumber-js integration
-const TelWidget: React.FC<WidgetProps> = ({ id, value, onChange, onBlur, onFocus, placeholder, disabled, readonly, required, label }) => {
-  const theme = useTheme();
-  const [selectedCountry, setSelectedCountry] = useState<CountryCode>('US');
-  const [phoneInput, setPhoneInput] = useState('');
-  const [error, setError] = useState<string>('');
-  const [isValid, setIsValid] = useState<boolean | null>(null);
-
-  const countryOptions = getCountryOptions();
-
-  // Initialize state from value
-  React.useEffect(() => {
-    if (value) {
-      try {
-        const parsed = parsePhoneNumber(value);
-        if (parsed) {
-          setSelectedCountry(parsed.country || 'US');
-          setPhoneInput(parsed.nationalNumber || '');
-        } else {
-          setPhoneInput(value);
-        }
-      } catch {
-        setPhoneInput(value);
-      }
-    }
-  }, [value]);
-
-  const handlePhoneChange = (newPhoneInput: string) => {
-    setPhoneInput(newPhoneInput);
-    setError('');
-
-    if (!newPhoneInput.trim()) {
-      onChange('');
-      return;
-    }
-
-    try {
-      // Try to parse with selected country
-      const phoneNumber = parsePhoneNumber(newPhoneInput, selectedCountry);
-
-      if (phoneNumber && phoneNumber.isValid()) {
-        // Format as international number
-        const formatted = phoneNumber.formatInternational();
-        onChange(formatted);
-        setError('');
-        setIsValid(true);
-      } else {
-        // Also check with isValidPhoneNumber for additional validation
-        const valid = isValidPhoneNumber(newPhoneInput, selectedCountry);
-        onChange(newPhoneInput);
-
-        if (newPhoneInput.length > 3 && !valid) {
-          setError('Invalid phone number format');
-          setIsValid(false);
-        } else if (newPhoneInput.length <= 3) {
-          setIsValid(null);
-        }
-      }
-    } catch (err) {
-      // Final validation check for any parsing errors
-      const valid = isValidPhoneNumber(newPhoneInput, selectedCountry);
-      onChange(newPhoneInput);
-
-      if (newPhoneInput.length > 3 && !valid) {
-        setError('Invalid phone number format');
-        setIsValid(false);
-      } else if (newPhoneInput.length <= 3) {
-        setIsValid(null);
-      }
-    }
-  };
-
-  const handleCountryChange = (newCountry: CountryCode) => {
-    setSelectedCountry(newCountry);
-
-    if (phoneInput) {
-      try {
-        const phoneNumber = parsePhoneNumber(phoneInput, newCountry);
-        if (phoneNumber && phoneNumber.isValid()) {
-          const formatted = phoneNumber.formatInternational();
-          onChange(formatted);
-          setError('');
-        } else {
-          // Validate with the new country
-          const isValid = isValidPhoneNumber(phoneInput, newCountry);
-          if (!isValid && phoneInput.length > 3) {
-            setError('Invalid phone number format for selected country');
-          } else {
-            setError('');
-          }
-        }
-      } catch {
-        // Validate even if parsing fails
-        const isValid = isValidPhoneNumber(phoneInput, newCountry);
-        if (!isValid && phoneInput.length > 3) {
-          setError('Invalid phone number format for selected country');
-        } else {
-          setError('');
-        }
-      }
-    }
-  };
-
-  const currentCountry = countryOptions.find((c) => c.code === selectedCountry);
-
-  const getBorderColor = () => {
-    if (isValid === true) return '#4caf50'; // Green for valid
-    if (isValid === false) return '#f44336'; // Red for invalid
-    return theme.palette.divider; // Theme-aware default
-  };
-
-  const getHoverBorderColor = () => {
-    if (isValid === true) return '#66bb6a'; // Lighter green on hover
-    if (isValid === false) return '#ef5350'; // Lighter red on hover
-    return theme.palette.text.primary; // Theme-aware hover
-  };
-
-  return (
-    <Box sx={{ display: 'flex', gap: 1, alignItems: 'flex-start' }}>
-      <Autocomplete
-        value={currentCountry || null}
-        onChange={(_, newValue) => {
-          if (newValue) {
-            handleCountryChange(newValue.code);
-          }
-        }}
-        options={countryOptions}
-        getOptionLabel={(option) => option.label}
-        renderInput={(params) => (
-          <MuiTextField
-            {...params}
-            label="Country"
-            variant="outlined"
-            sx={{
-              minWidth: 200,
-              '& .MuiOutlinedInput-root': {
-                '& fieldset': {
-                  borderColor: theme.palette.divider,
-                  borderWidth: '1px',
-                },
-                '&:hover fieldset': {
-                  borderColor: theme.palette.text.primary,
-                  borderWidth: '1px',
-                },
-                '&.Mui-focused fieldset': {
-                  borderColor: 'primary.main',
-                  borderWidth: '2px',
-                },
-              },
-            }}
-          />
-        )}
-        disabled={disabled || readonly}
-        size="small"
-      />
-
-      <MuiTextField
-        id={id}
-        type="tel"
-        label={required ? `${label || 'Phone Number'} *` : label || 'Phone Number'}
-        value={phoneInput}
-        onChange={(e) => handlePhoneChange(e.target.value)}
-        onBlur={onBlur && (() => onBlur(id, value))}
-        onFocus={onFocus && (() => onFocus(id, value))}
-        placeholder={placeholder || `Enter phone number (${currentCountry?.callingCode})`}
-        disabled={disabled}
-        slotProps={{ input: { readOnly: readonly } }}
-        error={!!error}
-        helperText={error || (currentCountry ? `Format: ${currentCountry.callingCode} XXX XXX XXXX` : '')}
-        fullWidth
-        variant="outlined"
-        size="small"
-        sx={{
-          '& .MuiInputLabel-root': {
-            '& .MuiInputLabel-asterisk': {
-              color: 'error.main',
-            },
-          },
-          '& .MuiOutlinedInput-root': {
-            '& fieldset': {
-              borderColor: getBorderColor(),
-              borderWidth: '1px',
-              transition: 'border-color 0.2s ease-in-out',
-            },
-            '&:hover fieldset': {
-              borderColor: getHoverBorderColor(),
-              borderWidth: '1px',
-            },
-            '&.Mui-focused fieldset': {
-              borderColor: isValid === false ? 'error.main' : 'primary.main',
-              borderWidth: '2px',
-            },
-            '&.Mui-error fieldset': {
-              borderColor: 'error.main',
-            },
-          },
-        }}
-      />
-    </Box>
-  );
-};
-
-// Custom TextWidget with Material-UI styling
-const TextWidget: React.FC<WidgetProps> = ({ id, value, onChange, onBlur, onFocus, placeholder, disabled, readonly, required, schema, label }) => {
-  const theme = useTheme();
-  const isEmail = schema.format === 'email';
-  const [isValid, setIsValid] = React.useState<boolean | null>(null);
-
-  const validateField = React.useCallback(
-    (fieldValue: string) => {
-      if (!fieldValue) {
-        if (required) {
-          setIsValid(false);
-          return false;
-        } else {
-          setIsValid(null);
-          return true;
-        }
-      }
-
-      // Email validation
-      if (isEmail) {
-        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-        const valid = emailRegex.test(fieldValue);
-        setIsValid(valid);
-        return valid;
-      }
-
-      // Basic validation for non-empty required fields
-      if (fieldValue.trim().length > 0) {
-        setIsValid(true);
-        return true;
-      }
-
-      setIsValid(false);
-      return false;
-    },
-    [required, isEmail]
-  );
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newValue = e.target.value;
-    validateField(newValue);
-    onChange(newValue);
-  };
-
-  const handleBlurEvent = () => {
-    validateField(value || '');
-    if (onBlur) onBlur(id, value);
-  };
-
-  React.useEffect(() => {
-    if (value) {
-      validateField(value);
-    }
-  }, [value, required, validateField]);
-
-  const getBorderColor = () => {
-    if (isValid === true) return '#4caf50'; // Green for valid
-    if (isValid === false) return '#f44336'; // Red for invalid
-    return theme.palette.divider; // Theme-aware default
-  };
-
-  const getHoverBorderColor = () => {
-    if (isValid === true) return '#66bb6a'; // Lighter green on hover
-    if (isValid === false) return '#ef5350'; // Lighter red on hover
-    return theme.palette.text.primary; // Theme-aware hover
-  };
-
-  return (
-    <MuiTextField
-      id={id}
-      label={required ? `${label} *` : label}
-      type={isEmail ? 'email' : 'text'}
-      value={value || ''}
-      onChange={handleChange}
-      onBlur={handleBlurEvent}
-      onFocus={onFocus && (() => onFocus(id, value))}
-      placeholder={placeholder}
-      disabled={disabled}
-      slotProps={{ input: { readOnly: readonly } }}
-      fullWidth
-      variant="outlined"
-      size="small"
-      sx={{
-        mb: 2,
-        '& .MuiInputLabel-root': {
-          '& .MuiInputLabel-asterisk': {
-            color: 'error.main',
-          },
-        },
-        '& .MuiOutlinedInput-root': {
-          '& fieldset': {
-            borderColor: getBorderColor(),
-            borderWidth: '1px',
-            transition: 'border-color 0.2s ease-in-out',
-          },
-          '&:hover fieldset': {
-            borderColor: getHoverBorderColor(),
-            borderWidth: '1px',
-          },
-          '&.Mui-focused fieldset': {
-            borderColor: isValid === false ? '#f44336' : 'primary.main',
-            borderWidth: '2px',
-          },
-        },
-      }}
-    />
-  );
-};
-
-// Custom Field Template
-const FieldTemplate: React.FC<FieldTemplateProps> = ({ children, description, errors, help, hidden }) => {
-  if (hidden) {
-    return <div style={{ display: 'none' }}>{children}</div>;
-  }
-
-  return (
-    <Box sx={{ mb: 2 }}>
-      {children}
-      {description && (
-        <Typography variant="label" sx={{ mt: 0.5, display: 'block', opacity: 0.7 }}>
-          {description}
-        </Typography>
-      )}
-      {errors && (
-        <Typography variant="label" sx={{ mt: 0.5, display: 'block', color: 'error.main' }}>
-          {errors}
-        </Typography>
-      )}
-      {help && (
-        <Typography variant="label" sx={{ mt: 0.5, display: 'block', opacity: 0.7 }}>
-          {help}
-        </Typography>
-      )}
-    </Box>
-  );
-};
-
-// Custom Object Field Template for nested objects
-const ObjectFieldTemplate: React.FC<ObjectFieldTemplateProps> = ({ title, description, properties }) => {
-  return (
-    <Box sx={{ mb: 3 }}>
-      {title && (
-        <Typography variant="heading" size="lg" sx={{ mb: 2 }}>
-          {title}
-        </Typography>
-      )}
-      {description && (
-        <Typography variant="subheading" sx={{ mb: 2 }}>
-          {description}
-        </Typography>
-      )}
-      <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(250px, 1fr))', gap: 2 }}>
-        {properties.map((prop) => (
-          <div key={prop.name}>{prop.content}</div>
-        ))}
-      </Box>
-    </Box>
-  );
-};
-
-// Custom Submit Button Template (hidden since we use our own buttons)
-const SubmitButton: React.FC<SubmitButtonProps> = () => {
-  return null; // We handle submit with our own buttons
-};
 
 const CreateIdentityForm: React.FC<CreateIdentityFormProps> = ({ onSuccess, onCancel }) => {
   const router = useRouter();
@@ -416,10 +39,7 @@ const CreateIdentityForm: React.FC<CreateIdentityFormProps> = ({ onSuccess, onCa
 
   const [selectedSchemaId, setSelectedSchemaId] = useState<string>('');
   const [formData, setFormData] = useState<any>({});
-  const [formSchema, setFormSchema] = useState<RJSFSchema | null>(null);
-
-  // Memoize country options to avoid recalculation
-  const countryOptions = React.useMemo(() => getCountryOptions(), []);
+  const [formSchema, setFormSchema] = useState<any | null>(null);
 
   // Custom widgets for better form experience
   const widgets = React.useMemo(
@@ -441,56 +61,6 @@ const CreateIdentityForm: React.FC<CreateIdentityFormProps> = ({ onSuccess, onCa
     }),
     []
   );
-
-  // Convert Kratos schema to RJSF schema
-  const convertKratosSchemaToRJSF = (kratosSchema: any): RJSFSchema => {
-    const schemaObj = kratosSchema as any;
-
-    if (schemaObj?.properties?.traits) {
-      return {
-        title: 'Identity Traits',
-        type: 'object',
-        properties: schemaObj.properties.traits.properties,
-        required: schemaObj.properties.traits.required || [],
-      };
-    }
-
-    return {
-      title: 'Identity Traits',
-      type: 'object',
-      properties: {},
-    };
-  };
-
-  // Create UI Schema for better form layout
-  const createUISchema = (schema: RJSFSchema): UiSchema => {
-    const uiSchema: UiSchema = {};
-
-    // Customize specific field types
-    Object.keys(schema.properties || {}).forEach((key) => {
-      const property = (schema.properties as any)[key];
-
-      if (property.format === 'email') {
-        uiSchema[key] = {
-          'ui:widget': 'email',
-        };
-      } else if (property.format === 'tel') {
-        // Use custom tel widget
-        uiSchema[key] = {
-          'ui:widget': 'tel',
-        };
-      }
-
-      // Handle nested objects (like name.first, name.last)
-      if (property.type === 'object' && property.properties) {
-        uiSchema[key] = {
-          'ui:field': 'object',
-        };
-      }
-    });
-
-    return uiSchema;
-  };
 
   const handleSchemaChange = (schemaId: string) => {
     setSelectedSchemaId(schemaId);

--- a/src/features/identities/components/shared-form-widgets.tsx
+++ b/src/features/identities/components/shared-form-widgets.tsx
@@ -1,0 +1,448 @@
+import React, { useState } from 'react';
+import { TextField as MuiTextField, useTheme } from '@mui/material';
+import { Autocomplete, Box, Typography } from '@/components/ui';
+import { WidgetProps, FieldTemplateProps, ObjectFieldTemplateProps, SubmitButtonProps } from '@rjsf/utils';
+import parsePhoneNumber, { isValidPhoneNumber, getCountries, getCountryCallingCode, CountryCode } from 'libphonenumber-js';
+
+// Memoize country options for autocomplete to avoid recalculation
+export const getCountryOptions = () => {
+  return getCountries()
+    .map((countryCode) => {
+      const callingCode = getCountryCallingCode(countryCode);
+      return {
+        code: countryCode,
+        name: new Intl.DisplayNames(['en'], { type: 'region' }).of(countryCode) || countryCode,
+        callingCode: `+${callingCode}`,
+        label: `${new Intl.DisplayNames(['en'], { type: 'region' }).of(countryCode)} (+${callingCode})`,
+      };
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+};
+
+// Custom tel widget component with libphonenumber-js integration
+export const TelWidget: React.FC<WidgetProps> = ({ id, value, onChange, onBlur, onFocus, placeholder, disabled, readonly, required, label }) => {
+  const theme = useTheme();
+  const [selectedCountry, setSelectedCountry] = useState<CountryCode>('US');
+  const [phoneInput, setPhoneInput] = useState('');
+  const [error, setError] = useState<string>('');
+  const [isValid, setIsValid] = useState<boolean | null>(null);
+
+  const countryOptions = getCountryOptions();
+
+  // Initialize state from value
+  React.useEffect(() => {
+    if (value) {
+      try {
+        const parsed = parsePhoneNumber(value);
+        if (parsed) {
+          setSelectedCountry(parsed.country || 'US');
+          setPhoneInput(parsed.nationalNumber || '');
+        } else {
+          setPhoneInput(value);
+        }
+      } catch {
+        setPhoneInput(value);
+      }
+    }
+  }, [value]);
+
+  const handlePhoneChange = (newPhoneInput: string) => {
+    setPhoneInput(newPhoneInput);
+    setError('');
+
+    if (!newPhoneInput.trim()) {
+      onChange('');
+      return;
+    }
+
+    try {
+      // Try to parse with selected country
+      const phoneNumber = parsePhoneNumber(newPhoneInput, selectedCountry);
+
+      if (phoneNumber && phoneNumber.isValid()) {
+        // Format as international number
+        const formatted = phoneNumber.formatInternational();
+        onChange(formatted);
+        setError('');
+        setIsValid(true);
+      } else {
+        // Also check with isValidPhoneNumber for additional validation
+        const valid = isValidPhoneNumber(newPhoneInput, selectedCountry);
+        onChange(newPhoneInput);
+
+        if (newPhoneInput.length > 3 && !valid) {
+          setError('Invalid phone number format');
+          setIsValid(false);
+        } else if (newPhoneInput.length <= 3) {
+          setIsValid(null);
+        }
+      }
+    } catch (err) {
+      // Final validation check for any parsing errors
+      const valid = isValidPhoneNumber(newPhoneInput, selectedCountry);
+      onChange(newPhoneInput);
+
+      if (newPhoneInput.length > 3 && !valid) {
+        setError('Invalid phone number format');
+        setIsValid(false);
+      } else if (newPhoneInput.length <= 3) {
+        setIsValid(null);
+      }
+    }
+  };
+
+  const handleCountryChange = (newCountry: CountryCode) => {
+    setSelectedCountry(newCountry);
+
+    if (phoneInput) {
+      try {
+        const phoneNumber = parsePhoneNumber(phoneInput, newCountry);
+        if (phoneNumber && phoneNumber.isValid()) {
+          const formatted = phoneNumber.formatInternational();
+          onChange(formatted);
+          setError('');
+        } else {
+          // Validate with the new country
+          const isValid = isValidPhoneNumber(phoneInput, newCountry);
+          if (!isValid && phoneInput.length > 3) {
+            setError('Invalid phone number format for selected country');
+          } else {
+            setError('');
+          }
+        }
+      } catch {
+        // Validate even if parsing fails
+        const isValid = isValidPhoneNumber(phoneInput, newCountry);
+        if (!isValid && phoneInput.length > 3) {
+          setError('Invalid phone number format for selected country');
+        } else {
+          setError('');
+        }
+      }
+    }
+  };
+
+  const currentCountry = countryOptions.find((c) => c.code === selectedCountry);
+
+  const getBorderColor = () => {
+    if (isValid === true) return '#4caf50'; // Green for valid
+    if (isValid === false) return '#f44336'; // Red for invalid
+    return theme.palette.divider; // Theme-aware default
+  };
+
+  const getHoverBorderColor = () => {
+    if (isValid === true) return '#66bb6a'; // Lighter green on hover
+    if (isValid === false) return '#ef5350'; // Lighter red on hover
+    return theme.palette.text.primary; // Theme-aware hover
+  };
+
+  return (
+    <Box sx={{ display: 'flex', gap: 1, alignItems: 'flex-start' }}>
+      <Autocomplete
+        value={currentCountry || null}
+        onChange={(_, newValue) => {
+          if (newValue) {
+            handleCountryChange(newValue.code);
+          }
+        }}
+        options={countryOptions}
+        getOptionLabel={(option) => option.label}
+        renderInput={(params) => (
+          <MuiTextField
+            {...params}
+            label="Country"
+            variant="outlined"
+            sx={{
+              minWidth: 200,
+              '& .MuiOutlinedInput-root': {
+                '& fieldset': {
+                  borderColor: theme.palette.divider,
+                  borderWidth: '1px',
+                },
+                '&:hover fieldset': {
+                  borderColor: theme.palette.text.primary,
+                  borderWidth: '1px',
+                },
+                '&.Mui-focused fieldset': {
+                  borderColor: 'primary.main',
+                  borderWidth: '2px',
+                },
+              },
+            }}
+          />
+        )}
+        disabled={disabled || readonly}
+        size="small"
+      />
+
+      <MuiTextField
+        id={id}
+        type="tel"
+        label={required ? `${label || 'Phone Number'} *` : label || 'Phone Number'}
+        value={phoneInput}
+        onChange={(e) => handlePhoneChange(e.target.value)}
+        onBlur={onBlur && (() => onBlur(id, value))}
+        onFocus={onFocus && (() => onFocus(id, value))}
+        placeholder={placeholder || `Enter phone number (${currentCountry?.callingCode})`}
+        disabled={disabled}
+        slotProps={{ input: { readOnly: readonly } }}
+        error={!!error}
+        helperText={error || (currentCountry ? `Format: ${currentCountry.callingCode} XXX XXX XXXX` : '')}
+        fullWidth
+        variant="outlined"
+        size="small"
+        sx={{
+          '& .MuiInputLabel-root': {
+            '& .MuiInputLabel-asterisk': {
+              color: 'error.main',
+            },
+          },
+          '& .MuiOutlinedInput-root': {
+            '& fieldset': {
+              borderColor: getBorderColor(),
+              borderWidth: '1px',
+              transition: 'border-color 0.2s ease-in-out',
+            },
+            '&:hover fieldset': {
+              borderColor: getHoverBorderColor(),
+              borderWidth: '1px',
+            },
+            '&.Mui-focused fieldset': {
+              borderColor: isValid === false ? 'error.main' : 'primary.main',
+              borderWidth: '2px',
+            },
+            '&.Mui-error fieldset': {
+              borderColor: 'error.main',
+            },
+          },
+        }}
+      />
+    </Box>
+  );
+};
+
+// Custom TextWidget with Material-UI styling
+export const TextWidget: React.FC<WidgetProps> = ({
+  id,
+  value,
+  onChange,
+  onBlur,
+  onFocus,
+  placeholder,
+  disabled,
+  readonly,
+  required,
+  schema,
+  label,
+}) => {
+  const theme = useTheme();
+  const isEmail = schema.format === 'email';
+  const [isValid, setIsValid] = React.useState<boolean | null>(null);
+
+  const validateField = React.useCallback(
+    (fieldValue: string) => {
+      if (!fieldValue) {
+        if (required) {
+          setIsValid(false);
+          return false;
+        } else {
+          setIsValid(null);
+          return true;
+        }
+      }
+
+      // Email validation
+      if (isEmail) {
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        const valid = emailRegex.test(fieldValue);
+        setIsValid(valid);
+        return valid;
+      }
+
+      // Basic validation for non-empty required fields
+      if (fieldValue.trim().length > 0) {
+        setIsValid(true);
+        return true;
+      }
+
+      setIsValid(false);
+      return false;
+    },
+    [required, isEmail]
+  );
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = e.target.value;
+    validateField(newValue);
+    onChange(newValue);
+  };
+
+  const handleBlurEvent = () => {
+    validateField(value || '');
+    if (onBlur) onBlur(id, value);
+  };
+
+  React.useEffect(() => {
+    if (value) {
+      validateField(value);
+    }
+  }, [value, required, validateField]);
+
+  const getBorderColor = () => {
+    if (isValid === true) return '#4caf50'; // Green for valid
+    if (isValid === false) return '#f44336'; // Red for invalid
+    return theme.palette.divider; // Theme-aware default
+  };
+
+  const getHoverBorderColor = () => {
+    if (isValid === true) return '#66bb6a'; // Lighter green on hover
+    if (isValid === false) return '#ef5350'; // Lighter red on hover
+    return theme.palette.text.primary; // Theme-aware hover
+  };
+
+  return (
+    <MuiTextField
+      id={id}
+      label={required ? `${label} *` : label}
+      type={isEmail ? 'email' : 'text'}
+      value={value || ''}
+      onChange={handleChange}
+      onBlur={handleBlurEvent}
+      onFocus={onFocus && (() => onFocus(id, value))}
+      placeholder={placeholder}
+      disabled={disabled}
+      slotProps={{ input: { readOnly: readonly } }}
+      fullWidth
+      variant="outlined"
+      size="small"
+      sx={{
+        mb: 2,
+        '& .MuiInputLabel-root': {
+          '& .MuiInputLabel-asterisk': {
+            color: 'error.main',
+          },
+        },
+        '& .MuiOutlinedInput-root': {
+          '& fieldset': {
+            borderColor: getBorderColor(),
+            borderWidth: '1px',
+            transition: 'border-color 0.2s ease-in-out',
+          },
+          '&:hover fieldset': {
+            borderColor: getHoverBorderColor(),
+            borderWidth: '1px',
+          },
+          '&.Mui-focused fieldset': {
+            borderColor: isValid === false ? '#f44336' : 'primary.main',
+            borderWidth: '2px',
+          },
+        },
+      }}
+    />
+  );
+};
+
+// Custom Field Template
+export const FieldTemplate: React.FC<FieldTemplateProps> = ({ children, description, errors, help, hidden }) => {
+  if (hidden) {
+    return <div style={{ display: 'none' }}>{children}</div>;
+  }
+
+  return (
+    <Box sx={{ mb: 2 }}>
+      {children}
+      {description && (
+        <Typography variant="label" sx={{ mt: 0.5, display: 'block', opacity: 0.7 }}>
+          {description}
+        </Typography>
+      )}
+      {errors && (
+        <Typography variant="label" sx={{ mt: 0.5, display: 'block', color: 'error.main' }}>
+          {errors}
+        </Typography>
+      )}
+      {help && (
+        <Typography variant="label" sx={{ mt: 0.5, display: 'block', opacity: 0.7 }}>
+          {help}
+        </Typography>
+      )}
+    </Box>
+  );
+};
+
+// Custom Object Field Template for nested objects
+export const ObjectFieldTemplate: React.FC<ObjectFieldTemplateProps> = ({ title, description, properties }) => {
+  return (
+    <Box sx={{ mb: 3 }}>
+      {title && (
+        <Typography variant="heading" size="lg" sx={{ mb: 2 }}>
+          {title}
+        </Typography>
+      )}
+      {description && (
+        <Typography variant="subheading" sx={{ mb: 2 }}>
+          {description}
+        </Typography>
+      )}
+      <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(250px, 1fr))', gap: 2 }}>
+        {properties.map((prop) => (
+          <div key={prop.name}>{prop.content}</div>
+        ))}
+      </Box>
+    </Box>
+  );
+};
+
+// Custom Submit Button Template (hidden since we use our own buttons)
+export const SubmitButton: React.FC<SubmitButtonProps> = () => {
+  return null; // We handle submit with our own buttons
+};
+
+// Helper to convert Kratos schema to RJSF schema
+export const convertKratosSchemaToRJSF = (kratosSchema: any) => {
+  const schemaObj = kratosSchema as any;
+
+  if (schemaObj?.properties?.traits) {
+    return {
+      title: 'Identity Traits',
+      type: 'object',
+      properties: schemaObj.properties.traits.properties,
+      required: schemaObj.properties.traits.required || [],
+    };
+  }
+
+  return {
+    title: 'Identity Traits',
+    type: 'object',
+    properties: {},
+  };
+};
+
+// Create UI Schema for better form layout
+export const createUISchema = (schema: any) => {
+  const uiSchema: any = {};
+
+  // Customize specific field types
+  Object.keys(schema.properties || {}).forEach((key) => {
+    const property = (schema.properties as any)[key];
+
+    if (property.format === 'email') {
+      uiSchema[key] = {
+        'ui:widget': 'email',
+      };
+    } else if (property.format === 'tel') {
+      uiSchema[key] = {
+        'ui:widget': 'tel',
+      };
+    }
+
+    // Handle nested objects (like name.first, name.last)
+    if (property.type === 'object' && property.properties) {
+      uiSchema[key] = {
+        'ui:field': 'object',
+      };
+    }
+  });
+
+  return uiSchema;
+};


### PR DESCRIPTION
- Extract shared form widgets (TelWidget, TextWidget, templates) to separate file
- Replace hardcoded fields with dynamic schema-based form generation in edit modal
- Fix incorrect field mapping that prevented editing identities with different schemas