### PR TITLE
fix: correct form selector in identity edit modal save button

### DIFF
--- a/src/features/identities/components/IdentityEditModal.tsx
+++ b/src/features/identities/components/IdentityEditModal.tsx
@@ -182,7 +182,7 @@ export const IdentityEditModal: React.FC<IdentityEditModalProps> = ({ open, onCl
                     label: 'Save Changes',
                     onClick: () => {
                       // Trigger form submission
-                      document.querySelector<HTMLFormElement>('.rjsf form')?.requestSubmit();
+                      document.querySelector<HTMLFormElement>('form.rjsf')?.requestSubmit();
                     },
                     loading: updateIdentityMutation.isPending,
                     disabled: false,


### PR DESCRIPTION
The selector `.rjsf form` was incorrect - RJSF renders as `<form class="rjsf">`, not a form nested inside a .rjsf container. Changed to `form.rjsf`.