### PR TITLE
Identity search now queries across all pages

### DIFF
--- a/dev/init-identities.sh
+++ b/dev/init-identities.sh
@@ -71,9 +71,9 @@ loyalty_tiers="bronze silver gold platinum diamond"
 statuses="active inactive on_leave"
 customer_statuses="active suspended closed"
 
-echo "Creating 15 default (person) identities..."
+echo "Creating 150 default (person) identities..."
 i=1
-while [ $i -le 15 ]; do
+while [ $i -le 150 ]; do
   EMAIL=$(generate_email)
   FIRST_NAME=$(get_random_element "$first_names")
   LAST_NAME=$(get_random_element "$last_names")
@@ -124,9 +124,9 @@ while [ $i -le 15 ]; do
   sleep 0.1
 done
 
-echo "Creating 10 organizational identities..."
+echo "Creating 100 organizational identities..."
 i=1
-while [ $i -le 10 ]; do
+while [ $i -le 100 ]; do
   EMAIL=$(generate_email)
   EMPLOYEE_ID=$(generate_employee_id)
   FIRST_NAME=$(get_random_element "$first_names")
@@ -184,9 +184,9 @@ while [ $i -le 10 ]; do
   sleep 0.1
 done
 
-echo "Creating 12 customer identities..."
+echo "Creating 120 customer identities..."
 i=1
-while [ $i -le 12 ]; do
+while [ $i -le 120 ]; do
   EMAIL=$(generate_email)
   CUSTOMER_ID=$(generate_customer_id)
   FIRST_NAME=$(get_random_element "$first_names")
@@ -271,10 +271,10 @@ while [ $i -le 12 ]; do
 done
 
 echo "✅ Identity generation complete!"
-echo "   📊 15 person identities (70% verified)"
-echo "   👥 10 organizational identities (80% verified)" 
-echo "   🛒 12 customer identities (60% verified)"
-echo "   🎯 Total: 37 test identities created"
+echo "   📊 150 person identities (70% verified)"
+echo "   👥 100 organizational identities (80% verified)"
+echo "   🛒 120 customer identities (60% verified)"
+echo "   🎯 Total: 370 test identities created"
 
 # Create marker file to indicate completion
 touch /tmp/init-complete

--- a/src/features/identities/components/IdentitiesTable.tsx
+++ b/src/features/identities/components/IdentitiesTable.tsx
@@ -131,7 +131,7 @@ const IdentitiesTable: React.FC = React.memo(() => {
     });
   }, [baseIdentities, searchTerm, getSchemaName, getIdentifier]);
 
-  const shouldUseSearchResults = searchComplete && searchResults.length > clientFilteredIdentities.length;
+  const shouldUseSearchResults = searchComplete && isSearching;
   const displayedIdentities = shouldUseSearchResults ? searchResults : clientFilteredIdentities;
 
   // Define columns


### PR DESCRIPTION
The search function had a flawed condition that compared result counts between client-side filtering (first 25 identities) and multi-page search (all identities):

  shouldUseSearchResults = searchComplete && searchResults.length > clientFilteredIdentities.length

Edge case bug:
- User searches for someone NOT in the first 25 identities
- Client-side filtering finds 3 matches in first 25 (e.g., "John", "Johnny", "Johnson")
- Multi-page search finds only 1 exact match on page 5 (e.g., the specific "John Doe" they want)
- Since 1 is NOT > 3, it incorrectly shows the 3 client-side results
- The actual target user on page 5 is never displayed

More generally, when a search term matches FEWER results globally than what's coincidentally in the first page, the multi-page results were ignored. This made it impossible to find certain users via search.

Fix: Always use multi-page search results when actively searching, regardless of count comparison. Multi-page search is the complete dataset; client-side filtering is just a fast preview of the first page.

Also increased test identities from 37 to 370 to make pagination bugs easier to reproduce during development.