### PR TITLE
feat(settings): Add Ory Network Mode toggle to Settings page

### DIFF
--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -11,6 +11,8 @@ import {
   useHydraEndpoints,
   useSetKratosEndpoints,
   useSetHydraEndpoints,
+  useIsOryNetwork,
+  useSetIsOryNetwork,
   useResetSettings,
   useIsValidUrl,
 } from '@/features/settings/hooks/useSettings';
@@ -31,6 +33,10 @@ interface HydraSettingsForm {
 export default function SettingsPage() {
   const [showSuccessMessage, setShowSuccessMessage] = useState(false);
   const { theme: currentTheme, toggleTheme } = useTheme();
+
+  // Ory Network mode
+  const isOryNetwork = useIsOryNetwork();
+  const setIsOryNetwork = useSetIsOryNetwork();
 
   // Kratos settings
   const kratosEndpoints = useKratosEndpoints();
@@ -168,6 +174,38 @@ export default function SettingsPage() {
                   </Typography>
                 </Grid>
               </Grid>
+            </SectionCard>
+          </Grid>
+
+          {/* Connection Mode */}
+          <Grid size={{ xs: 12 }}>
+            <SectionCard
+              title={
+                <FlexBox align="center" gap={1}>
+                  <CloudIcon />
+                  <Typography variant="heading" size="lg">
+                    Connection Mode
+                  </Typography>
+                </FlexBox>
+              }
+            >
+              <FlexBox align="center" justify="space-between">
+                <Box>
+                  <Typography variant="label">Ory Network Mode</Typography>
+                  <Typography variant="body" color="secondary" sx={{ mt: 0.5 }}>
+                    Enable when connecting to Ory Network (managed service). This skips health checks that aren&apos;t available on Ory
+                    Network.
+                  </Typography>
+                </Box>
+                <Switch
+                  checked={isOryNetwork}
+                  onChange={(e) => {
+                    setIsOryNetwork(e.target.checked);
+                    setShowSuccessMessage(true);
+                  }}
+                  color="primary"
+                />
+              </FlexBox>
             </SectionCard>
           </Grid>
 

--- a/src/features/analytics/hooks/useAnalytics.ts
+++ b/src/features/analytics/hooks/useAnalytics.ts
@@ -7,7 +7,7 @@ import { useIsOryNetwork, useSettingsLoaded } from '@/features/settings/hooks/us
 // Health check hooks
 const useKratosHealthCheck = (isOryNetwork: boolean, isSettingsLoaded: boolean) => {
   return useQuery({
-    queryKey: ['health', 'kratos'],
+    queryKey: ['health', 'kratos', isOryNetwork],
     queryFn: async () => {
       // Ory Network does not provide health check endpoints
       if (isOryNetwork) {
@@ -23,7 +23,7 @@ const useKratosHealthCheck = (isOryNetwork: boolean, isSettingsLoaded: boolean) 
 
 const useHydraHealthCheck = (isOryNetwork: boolean, isSettingsLoaded: boolean) => {
   return useQuery({
-    queryKey: ['health', 'hydra'],
+    queryKey: ['health', 'hydra', isOryNetwork],
     queryFn: async () => {
       // Ory Network does not provide health check endpoints
       if (isOryNetwork) {

--- a/src/features/settings/hooks/useSettings.ts
+++ b/src/features/settings/hooks/useSettings.ts
@@ -19,6 +19,7 @@ export interface SettingsStoreState {
   isOryNetwork: boolean;
   setKratosEndpoints: (endpoints: KratosEndpoints) => void;
   setHydraEndpoints: (endpoints: HydraEndpoints) => void;
+  setIsOryNetwork: (value: boolean) => void;
   resetToDefaults: () => void;
   isValidUrl: (url: string) => boolean;
   isLoaded: boolean;
@@ -128,11 +129,16 @@ export const useSettingsStore = create<SettingsStoreState>()(
         }
       },
 
+      setIsOryNetwork: (value: boolean) => {
+        set({ isOryNetwork: value });
+      },
+
       resetToDefaults: async () => {
         const defaultEndpoints = await fetchServerDefaults();
         set({
           kratosEndpoints: defaultEndpoints.kratos,
           hydraEndpoints: defaultEndpoints.hydra,
+          isOryNetwork: defaultEndpoints.isOryNetwork,
         });
 
         // Set cookies for middleware to read
@@ -188,6 +194,7 @@ export const useHydraEndpoints = () => useSettingsStore((state) => state.hydraEn
 export const useIsOryNetwork = () => useSettingsStore((state) => state.isOryNetwork);
 export const useSetKratosEndpoints = () => useSettingsStore((state) => state.setKratosEndpoints);
 export const useSetHydraEndpoints = () => useSettingsStore((state) => state.setHydraEndpoints);
+export const useSetIsOryNetwork = () => useSettingsStore((state) => state.setIsOryNetwork);
 export const useResetSettings = () => useSettingsStore((state) => state.resetToDefaults);
 export const useIsValidUrl = () => useSettingsStore((state) => state.isValidUrl);
 export const useLoadDefaults = () => useSettingsStore((state) => state.loadDefaults);


### PR DESCRIPTION
- Add setIsOryNetwork action to settings store for user control
- Add Connection Mode section with toggle in Settings page
- Include isOryNetwork in health check query keys for cache invalidation
- Reset to defaults now also resets isOryNetwork flag

This allows users to explicitly enable Ory Network mode via the UI, which skips health checks that aren't available on Ory Network. The setting is persisted to localStorage like other settings.