### PR TITLE
feat(identities): add schema ID tooltip to identity creation dropdown

### DIFF
--- a/src/features/identities/components/CreateIdentityForm.tsx
+++ b/src/features/identities/components/CreateIdentityForm.tsx
@@ -2,7 +2,7 @@ import { Cancel, Save } from "@mui/icons-material";
 import Form from "@rjsf/mui";
 import validator from "@rjsf/validator-ajv8";
 import React, { useState } from "react";
-import { Alert, Box, Button, Card, FormControl, InputLabel, MenuItem, Select, Spinner, Typography } from "@/components/ui";
+import { Alert, Box, Button, Card, FormControl, InputLabel, MenuItem, Select, Spinner, Tooltip, Typography } from "@/components/ui";
 
 // Add custom format for tel to avoid validation warnings
 validator.ajv.addFormat("tel", {
@@ -142,7 +142,9 @@ const CreateIdentityForm: React.FC<CreateIdentityFormProps> = ({ onSuccess, onCa
 					>
 						{schemas?.map((schema: IdentitySchemaContainer) => (
 							<MenuItem key={schema.id} value={schema.id}>
-								{(schema.schema as any)?.title || schema.id}
+								<Tooltip title={`Schema ID: ${schema.id}`} placement="right">
+									<span style={{ display: "block", width: "100%" }}>{(schema.schema as any)?.title || schema.id}</span>
+								</Tooltip>
 							</MenuItem>
 						))}
 					</Select>

--- a/src/features/identities/components/shared-form-widgets.tsx
+++ b/src/features/identities/components/shared-form-widgets.tsx
@@ -462,19 +462,19 @@ export const FieldTemplate: React.FC<FieldTemplateProps> = ({ children, descript
 		<Box sx={{ mb: 2 }}>
 			{children}
 			{description && (
-				<Typography variant="label" sx={{ mt: 0.5, display: "block", opacity: 0.7 }}>
+				<Box component="span" sx={{ mt: 0.5, display: "block", opacity: 0.7, fontSize: "0.875rem" }}>
 					{description}
-				</Typography>
+				</Box>
 			)}
 			{errors && (
-				<Typography variant="label" sx={{ mt: 0.5, display: "block", color: "error.main" }}>
+				<Box component="span" sx={{ mt: 0.5, display: "block", color: "error.main", fontSize: "0.875rem" }}>
 					{errors}
-				</Typography>
+				</Box>
 			)}
 			{help && (
-				<Typography variant="label" sx={{ mt: 0.5, display: "block", opacity: 0.7 }}>
+				<Box component="span" sx={{ mt: 0.5, display: "block", opacity: 0.7, fontSize: "0.875rem" }}>
 					{help}
-				</Typography>
+				</Box>
 			)}
 		</Box>
 	);


### PR DESCRIPTION
Show schema ID in a tooltip on hover in the schema selection dropdown, making it easier to distinguish schemas with the same name.

Also fix hydration error caused by nested h6 elements in FieldTemplate by using Box with span component instead of Typography.

Closes #70